### PR TITLE
[fix]環境によって表示されないバグを修正

### DIFF
--- a/Source/Option.cpp
+++ b/Source/Option.cpp
@@ -120,8 +120,10 @@ void Option::Draw() {
 	DrawString(STRING_XBGM, STRING_YBGM, "BGM Volume", GetColor(0, 0, 0));
 
 	for (int i = 0; i < bgmVolume; i++) {
-		DrawBoxAA(100 + (i * BGMBAR_WIDTH) + ((i + 1) * BGMBAR_INTERVAL), 329, (100 + BGMBAR_WIDTH) + (i * BGMBAR_WIDTH) + ((i + 1) * BGMBAR_INTERVAL),
-			329 - BGMBAR_HEIGHT - (BGMBAR_HEIGHT * i), GetColor(0, 0, 0), TRUE);
+		DrawBoxAA(100 + (i * BGMBAR_WIDTH) + ((i + 1) * BGMBAR_INTERVAL),
+			329 - BGMBAR_HEIGHT - (BGMBAR_HEIGHT * i),
+			(100 + BGMBAR_WIDTH) + (i * BGMBAR_WIDTH) + ((i + 1) * BGMBAR_INTERVAL),
+			329, GetColor(0, 0, 0), TRUE);
 	}
 
 	//SE関連のUIの表示
@@ -129,8 +131,10 @@ void Option::Draw() {
 	DrawString(STRING_XSE, STRING_YSE, "SE Volume", GetColor(0, 0, 0));
 
 	for (int i = 0; i < seVolume; i++) {
-		DrawBoxAA(100 + (i * SEBAR_WIDTH) + ((i + 1) * SEBAR_INTERVAL), 663, (100 + SEBAR_WIDTH) + (i * SEBAR_WIDTH) + ((i + 1) * SEBAR_INTERVAL),
-			663 - SEBAR_HEIGHT - (SEBAR_HEIGHT * i), GetColor(0, 0, 0), TRUE);
+		DrawBoxAA(100 + (i * SEBAR_WIDTH) + ((i + 1) * SEBAR_INTERVAL),
+			663 - SEBAR_HEIGHT - (SEBAR_HEIGHT * i),
+			(100 + SEBAR_WIDTH) + (i * SEBAR_WIDTH) + ((i + 1) * SEBAR_INTERVAL),
+			663, GetColor(0, 0, 0), TRUE);
 	}
 
 	//キー関連のUIの表示処理


### PR DESCRIPTION
## 概要

開発環境によって音量調整バーが表示されないバグの修正

## 技術的変更点概要

DrawBoxAAの仕様かわからないが、-方向に数値が加算された場合表示されない環境が存在するようなので
-方向に加算ではなく+方向に加算するように修正

## 今回保留した項目とTODOリスト

BGM・SEのボリューム調整をできるように修正

## その他
