### PR TITLE
[update]プレイヤーと弾のバグ修正

### DIFF
--- a/Source/BasePlayer.h
+++ b/Source/BasePlayer.h
@@ -42,6 +42,7 @@ private:
 	int speed;		                //プレイヤーの移動速度
 	int power;		                //プレイヤーの攻撃力
 	int stanTime;	                //プレイヤーのスタンタイム
+	int stanTime_stay;              //一度スタンしてから次にまたスタンするまでの時間
 	int AttackTime;                 //攻撃間隔
 
 	float width;
@@ -65,7 +66,7 @@ private:
 	bool isDamage;                  //プレイヤーの被弾フラグ
 	bool isAttack;                  //攻撃フラグ
 	bool isStan;                    //スタン中かどうかのフラグ
-
+	bool isStan_Next;               //スタンが起こる状態かどうかのフラグ
 public:
 	//当たり判定
 	bool ClisionHit(float mx, float my, float mw, float mh,
@@ -88,7 +89,7 @@ public:
 	void Attack();         //攻撃処理
 
 	//スタン処理
-	void Stan(float eX, float eY, float eW, float eH);           
+	void Stan();           
 
 	void Set_x(float _x) { pos.x = _x; }                        //セッター
 	void Set_y(float _y) { pos.y = _y; }                        //セッター

--- a/Source/Bullet.cpp
+++ b/Source/Bullet.cpp
@@ -9,13 +9,12 @@
 Bullet::Bullet(VECTOR& position, int pl_pos, bool pl_attack)
 {
 	//’e‚Ì”­¶ˆÊ’u
-	pos = position;
+	pos.x = position.x + 12;
+
+	pos.y = position.y + 12;
 
 	//i‚Ş•ûŒü
 	Bullet_Move = pl_pos;
-
-	//“–‚½‚è”»’è
-	isHit = false;
 
 	//”­Ë’†‚©‚Ç‚¤‚©
 	isActive = pl_attack;
@@ -37,8 +36,8 @@ Bullet::~Bullet()
 bool Bullet::ClisionHit(float mx, float my, float mw, float mh,
 	float ox, float oy, float ow, float oh)
 {
-	if (mx < (ox + ow) && my < (oy + oh) &&
-		ox < (mx + mw) && oy < (my + mh))
+	if (mx <= (ox + ow) && my <= (oy + oh) &&
+		ox <= (mx + mw) && oy <= (my + mh))
 	{
 		return true;
 	}
@@ -49,9 +48,14 @@ bool Bullet::ClisionHit(float mx, float my, float mw, float mh,
 }
 void Bullet::Draw()
 {
-	//’e‚Ì•`‰æ
+	//’e‚ÌF
 	Cr = GetColor(255, 255, 255);
-	DrawCircle(pos.x + 24, pos.y + 24, 5.0, Cr, TRUE);
+
+	//’e‚Ì•`‰æ
+	DrawBox(pos.x, pos.y, pos.x + width, pos.y + height, Cr, TRUE);
+
+	//’e‚Ì“–‚½‚è”»’è
+	DrawBox(Get_x(), Get_y(), pos.x + Get_width(), pos.y + Get_height(), GetColor(255, 0, 0), FALSE);
 }
 void Bullet::Update(EnemyManager* _eManager)
 {
@@ -84,12 +88,11 @@ void Bullet::Update(EnemyManager* _eManager)
 		isActive= false;
 	}
 	for (int i = 0; i < _eManager->Get_enemyNum(); i++) {
-		isHit = ClisionHit(Get_x(), Get_y(), Get_width(), Get_height(),
-			_eManager->Get_x(i), _eManager->Get_y(i), _eManager->Get_width(i), _eManager->Get_height(i));
-	}
-	if (isHit == true)
-	{
-		isActive = false;
+		if (ClisionHit(Get_x(), Get_y(), Get_width(), Get_height(),
+			_eManager->Get_x(i), _eManager->Get_y(i), _eManager->Get_width(i), _eManager->Get_height(i)))
+		{
+			isActive = false;
+		}
 	}
 
 }

--- a/Source/Bullet.h
+++ b/Source/Bullet.h
@@ -50,7 +50,6 @@ public:
 	float Get_height() { return height; }     //heightゲッター
 
 	bool Get_isActive() { return isActive; } //弾が攻撃中かどうかのゲッター
-	bool Get_isHit() { return isHit; }       //弾が当たったかどうかのゲッター
 
 };
 

--- a/Source/BulletManager.cpp
+++ b/Source/BulletManager.cpp
@@ -49,7 +49,7 @@ void BulletManager::Update(EnemyManager* _enemyManager)
 			bullet[i]->Update(_enemyManager);
 
 			//弾が画面外に出ていた場合か弾が敵に当たった場合
-			if (bullet[i]->Get_isActive() == false || bullet[i]->Get_isHit() == true)
+			if (bullet[i]->Get_isActive() == false)
 			{
 				//削除してNULLを入れて、また使えるようにする
 				delete bullet[i];
@@ -82,13 +82,6 @@ bool BulletManager::Get_IsActive(int i) {
 
 	return false;
 }
-//弾が当たってるかどうかのゲッター
-bool BulletManager::Get_IsHit(int i) {
-	if (bullet[i] != NULL) {
-		return bullet[i]->Get_isHit();
-	}
-}
-
 //弾のx座標ゲッター
 float BulletManager::Get_X(int i) {
 	if (bullet[i] != NULL) {


### PR DESCRIPTION
## 概要
プレイヤーと弾関連
## 技術的変更点概要
・プレイヤーの移動バグ
・移動中に弾が撃てるですけどバグ
・弾が消えないバグ
・スタン処理やばすぎバグ
上記のバグの修正

## 今回保留した項目とTODOリスト

弾が消えるようになったが、エネミーが死ななくなったのでそれ関連の修正を行う予定

## その他

* レビュワーに対する注意点 (ここはこういう風に思ったけどこういう風に実装した、ここはこうしようと思ったんだけどこういう悩みがありやめた、など注意点があれば)
