### PR TITLE
Feature/buff manager

### DIFF
--- a/Source/BuffManager.cpp
+++ b/Source/BuffManager.cpp
@@ -6,15 +6,119 @@
 BuffManager::BuffManager() {
 	powerLevel = 0;
 	speedLevel = 0;
-	powerBuff = 0.0f;
-	speedBuff = 0.0f;
+	isPowerLevelMax = false;
+	isSpeedLevelMax = false;
+
+	isLevelDown = false;
+
+	powerBuff = POWERBUFF_LV0;
+	speedBuff = SPEEDBUFF_LV0;
 }
 
 void BuffManager::Update(ItemManager* _itemManager, EnemyManager* _enemyManager) {
+	//レベルダウンフラグが有効なとき、無効状態へ
+	if (isLevelDown == true) {
+		isLevelDown = false;
+	}
+
+	//バフの効力を適用
+	switch (powerLevel) {
+	case 0:
+		powerBuff = POWERBUFF_LV0;
+		break;
+	case 1:
+		powerBuff = POWERBUFF_LV1;
+		break;
+	case 2:
+		powerBuff = POWERBUFF_LV2;
+		break;
+	case 3:
+		powerBuff = POWERBUFF_LV3;
+		break;
+	}
+
+	//バフの効力を適用
+	switch (speedLevel) {
+	case 0:
+		speedBuff = SPEEDBUFF_LV0;
+		break;
+	case 1:
+		speedBuff = SPEEDBUFF_LV1;
+		break;
+	case 2:
+		speedBuff = SPEEDBUFF_LV2;
+		break;
+	case 3:
+		speedBuff = SPEEDBUFF_LV3;
+		break;
+	}
 
 	//仮置きUI(UIが完成したら撤去させる)
 	//DrawFormatString(0, 550, GetColor(255, 255, 255), "パワーバフレベル : %d", powerLevel);
 	//DrawFormatString(0, 575, GetColor(255, 255, 255), "スピードバフレベル : %d", speedLevel);
 	//DrawFormatString(0, 600, GetColor(255, 255, 255), "パワーバフ : %f", powerBuff);
 	//DrawFormatString(0, 625, GetColor(255, 255, 255), "スピードバフ : %f", speedBuff);
+}
+
+void BuffManager::DownBuffLevel() {
+	//パワーバフレベルが0以下の場合
+	if (powerLevel <= 0) {
+		powerLevel = 0;
+	}
+	//0より多い場合
+	else {
+		powerLevel--;
+	}
+
+	//パワーバフレベルがマックスだった場合
+	if (isPowerLevelMax == true) {
+		isPowerLevelMax = false;
+	}
+
+	//スピードバフレベルが0以下の場合
+	if (speedLevel <= 0) {
+		speedLevel = 0;
+	}
+	//0より多い場合
+	else {
+		speedLevel--;
+	}
+
+	//スピードバフレベルがマックスの場合
+	if (isSpeedLevelMax == true) {
+		isSpeedLevelMax = false;
+	}
+
+	//レベルダウンフラグをオンにする
+	isLevelDown = true;
+}
+
+int BuffManager::PowerBuff_LevelUpCheck(int _powerCount) {
+	//_powerCountが15以上でレベルマックスでない場合
+	if (_powerCount >= 15 && isPowerLevelMax == false) {
+		powerLevel++;
+
+		if (powerLevel == MAX_BUFFLEVEL) {
+			isPowerLevelMax = true;
+		}
+
+		return 0;
+	}
+
+	return _powerCount;
+}
+
+int BuffManager::SpeedBuff_LevelUpCheck(int _speedCount) {
+	//_powerCountが15以上でレベルマックスでない場合
+	if (_speedCount >= 15 && isSpeedLevelMax == false) {
+		speedLevel++;
+
+		if (speedLevel == MAX_BUFFLEVEL) {
+			isSpeedLevelMax = true;
+		}
+
+		return 0;
+	}
+
+	return _speedCount;
 }

--- a/Source/BuffManager.h
+++ b/Source/BuffManager.h
@@ -9,10 +9,25 @@ class ItemManager;
 /// </summary>
 class BuffManager final {
 private:
+	const int MAX_BUFFLEVEL = 3;	//バフレベルの最大値
 
+	const float POWERBUFF_LV0 = 1.0f;	//攻撃バフLv0
+	const float POWERBUFF_LV1 = 1.25f;	//攻撃バフLv1
+	const float POWERBUFF_LV2 = 1.5f;	//攻撃バフLv2
+	const float POWERBUFF_LV3 = 1.75f;	//攻撃バフLv3
 
-	int powerLevel;		//現在のパワーバフレベル
-	int speedLevel;		//現在のスピードバフレベル
+	const float SPEEDBUFF_LV0 = 1.0f;	//速度バフLv0
+	const float SPEEDBUFF_LV1 = 1.25f;	//速度バフLv1
+	const float SPEEDBUFF_LV2 = 1.5f;	//速度バフLv2
+	const float SPEEDBUFF_LV3 = 1.75f;	//速度バフLv3
+
+	int powerLevel;			//現在のパワーバフレベル
+	int speedLevel;			//現在のスピードバフレベル
+	bool isPowerLevelMax;	//現在のパワーバフのレベルマックスフラグ
+	bool isSpeedLevelMax;	//現在のスピードバフのレベルマックスフラグ
+
+	bool isLevelDown;	//レベルダウンフラグ
+
 	float powerBuff;	//バフするパワー
 	float speedBuff;	//バフする速度
 public:
@@ -21,7 +36,31 @@ public:
 	/// </summary>
 	BuffManager();
 
+	/// <summary>
+	/// 更新処理
+	/// </summary>
+	/// <param name="_itemManager">アイテムマネージャーの情報</param>
+	/// <param name="_enemyManager">エネミーマネージャーの情報</param>
 	void Update(ItemManager* _itemManager, EnemyManager* _enemyManager);
+
+	/// <summary>
+	/// レベルダウンの処理
+	/// </summary>
+	void DownBuffLevel();
+
+	/// <summary>
+	///	パワーバフレベルのレベル上昇処理
+	/// </summary>
+	/// <param name="_powerCount">パワーアイテムの取得数</param>
+	/// <returns>取得した値 or 0(Errorのとき)</returns>
+	int PowerBuff_LevelUpCheck(int _powerCount);
+
+	/// <summary>
+	/// スピードバフレベルのレベル上昇処理
+	/// </summary>
+	/// <param name="_speedCount">スピードアイテムの取得数</param>
+	/// <returns>取得した値 or 0(Errorのとき)</returns>
+	int SpeedBuff_LevelUpCheck(int _speedCount);
 
 	/// <summary>
 	/// 現在のパワーバフレベルを取得する
@@ -46,6 +85,24 @@ public:
 	/// </summary>
 	/// <returns>バフする速度</returns>
 	float GetSpeedBuff() { return speedBuff; }
+
+	/// <summary>
+	/// 現在のパワーバフのレベルマックスフラグを取得する
+	/// </summary>
+	/// <returns>現在のパワーバフのレベルマックスフラグ</returns>
+	bool GetIsPowerLevelMax() { return isPowerLevelMax; }
+
+	/// <summary>
+	/// 現在のスピードバフのレベルマックスフラグを取得する
+	/// </summary>
+	/// <returns>現在のスピードバフのレベルマックスフラグ</returns>
+	bool GetIsSpeedLevelMax() { return isSpeedLevelMax; }
+
+	/// <summary>
+	/// レベルダウンフラグを取得する
+	/// </summary>
+	/// <returns>レベルダウンフラグ</returns>
+	bool GetIsLevelDown() { return isLevelDown; }
 };
 
 #endif // !_BUFFMANAGER_H


### PR DESCRIPTION
## 概要
* **[add]** バフレベルの上昇値の定数の追加
* **[add]** バフレベルの最大値を定数化
* **[add]** 各バフレベルのレベルマックスフラグを追加
* **[add]** レベルダウンフラグを追加
* **[add]** 追加したフラグのゲッターを追加
* **[add]** レベルダウンの処理を追加
* **[add]** 各バフのレベルアップ処理を追加
## 技術的変更点概要
* バフレベルの上昇値の定数の追加
`0.25 刻みで 1.0 ~ 1.75 でconst int型変数に格納しています`
* バフレベルの最大値を定数化
`const int MAX_BUFFLEVEL = 3;`
* 追加したフラグのゲッターを追加
`bool GetIsPowerLevelMax(){ return isPowerLevelMax; }`
`bool GetIsSpeedLevelMax(){ return isSpeedLevelMax; }`
`bool GetIsLevelDown(){ return isLevelDown; }`
* レベルダウンの処理を追加
```c++
void BuffManager::DownBuffLevel() {
    if (powerLevel <= 0) {
        powerLevel = 0;
    }
    else {
        powerLevel--;
    }

    if (isPowerLevelMax == true) {
        isPowerLevelMax = false;
    }

    if (speedLevel <= 0) {
        speedLevel = 0;
    }
    else {
        speedLevel--;
    }

    if (isSpeedLevelMax == true) {
        isSpeedLevelMax = false;
    }

    isLevelDown = true;
}
```
* 各バフのレベルアップ処理を追加
```c++
int BuffManager::PowerBuff_LevelUpCheck(int _powerCount) {
    if (_powerCount >= 15 && isPowerLevelMax == false) {
        powerLevel++;

        if (powerLevel == MAX_BUFFLEVEL) {
            isPowerLevelMax = true;
        }

        return 0;
    }

    return _powerCount;
}
```
```c++
int BuffManager::SpeedBuff_LevelUpCheck(int _speedCount) {
    if (_speedCount >= 15 && isSpeedLevelMax == false) {
        speedLevel++;

        if (speedLevel == MAX_BUFFLEVEL) {
            isSpeedLevelMax = true;
        }

        return 0;
    }

    return _speedCount;
}
```
## 今回保留した項目とTODOリスト
**とりあえずは終了だと思います**
**開発終盤のバランス調整まではとりあえずなしだと思います**
## その他
**追加してほしい、ここの処理をもっと複雑にしてほしいなど要望があれば**
**できる範囲内で追加、修正をおこなっていくのでご連絡ください**