### PR TITLE
Feature/ui5

### DIFF
--- a/Source/Ui.cpp
+++ b/Source/Ui.cpp
@@ -1,7 +1,7 @@
 #include <DxLib.h>
 #include "Ui.h"
 
-//HPバーの表示と中身の処理
+//HPバーの表示と中身の処理(MainCastle)
 void UI::Get_CastleDurability()
 {
 	DrawBox(HPMOJI_X + 10, HPMOJI_Y, HPMOJI_X + HPBAR_X, HPMOJI_Y + 20, GetColor(255, 255, 255), FALSE);		//HPという文字を表示するための枠
@@ -27,6 +27,34 @@ void UI::Get_CastleDurability()
 	}
 }
 
+//HPバーの表示と中身の処理(SubCastle) 形だけ
+void UI::Get_SubCastleDurability()
+{
+
+	DrawBox(HPMOJI_X + 10, HPMOJI_Y + 200, HPMOJI_X + HPBAR_X, HPMOJI_Y + 20 + 200, GetColor(255, 255, 255), FALSE);		//HPという文字を表示するための枠
+
+	DrawString(HPMOJI_X + 20, HPMOJI_Y + 2 + 200, "HP", GetColor(255, 255, 255));						//HPという文字を表示するため
+
+	DrawBox(HPBAR_X, HPBAR_Y + 200, (HPBAR_X1 + 200) / 2, HPBAR_Y1 + 20 + 200, GetColor(255, 255, 255), FALSE);		//HPバーの枠線(白)
+
+	percent = MAX_SABDURABILTY / 3;				//ピンチ時にHPゲージを赤色にするための割合(３割)　＊要調整
+
+	if (CastleDurability <= 0)					//HPゲージが0以下になってもゲージは0で止める
+	{
+		CastleDurability = 0;
+	}
+
+	if (CastleDurability <= percent)			//３割以下でHPゲージが赤になる	
+	{
+		DrawBox(HPGAUGE_X, HPGAUGE_Y, (HPGAUGE_X1 + 200 * CastleDurability) / 2 / MAX_SABDURABILTY, HPGAUGE_Y1 + 20, GetColor(255, 0, 0), TRUE);		//ピンチ用HPゲージ(赤）
+	}
+	else
+	{
+		DrawBox(HPGAUGE_X, HPGAUGE_Y + 200, (HPGAUGE_X1 + 250 * CastleDurability / 2)  / 2 / MAX_SABDURABILTY, HPGAUGE_Y1 + 20 + 200, GetColor(0, 255, 0), TRUE);		//通常用HPゲージ(緑)
+		DrawFormatString(PMOJI_X + 10, PMOJI_Y -10, GetColor(255, 255, 255), "%d", HPGAUGE_X1);
+	}
+}
+
 void UI::Get_BuffPoint() 
 {
 	//Pアイテム
@@ -47,13 +75,6 @@ void UI::Get_BuffPoint()
 
 }
 
-//操作説明
-void UI::PlayGuide()
-{
-	DrawString(700, 10, "十字キーで上下左右に移動", GetColor(255, 255, 255));
-	DrawString(700, 60, "〇〇でポーズメニュー表示", GetColor(255, 255, 255));
-	DrawString(700, 110, "Zキーで弾発射", GetColor(255, 255, 255));
-}
 
 //更新
 void UI::Update(CastleManager* _castlemanager, ItemManager* _itemmanager, BuffManager* _buffmanager)
@@ -69,6 +90,6 @@ void UI::Update(CastleManager* _castlemanager, ItemManager* _itemmanager, BuffMa
 void UI::Draw()
 {
 	Get_CastleDurability();
+	Get_SubCastleDurability();
 	Get_BuffPoint();
-	PlayGuide();
 }

--- a/Source/Ui.cpp
+++ b/Source/Ui.cpp
@@ -27,6 +27,26 @@ void UI::Get_CastleDurability()
 	}
 }
 
+void UI::Get_BuffPoint() 
+{
+	//Pアイテム
+	DrawBox(PMOJI_X, PMOJI_Y, PBAR_X1, PMOJI_Y + 20, GetColor(255, 255, 255), FALSE);										//文字
+	DrawFormatString(PMOJI_X + 10, PMOJI_Y + 2, GetColor(255, 255, 255), "PLv%d", pBuffLevel);
+
+	DrawBox(PBAR_X, PBAR_Y, PBAR_X1 + 200, PBAR_Y1 + 20, GetColor(255, 255, 255), FALSE);									//枠
+	
+	DrawBox(PGAUGE_X, PGAUGE_Y, PGAUGE_X1 + 200 * pBuffPoint / MAX_BUFF, PGAUGE_Y1 + 20, GetColor(0, 255, 0), TRUE);	//ゲージ
+	
+	//Sアイテム
+	DrawBox(SMOJI_X, SMOJI_Y, SBAR_X1, SMOJI_Y + 20, GetColor(255, 255, 255), FALSE);										//文字
+	DrawFormatString(SMOJI_X + 10, SMOJI_Y + 2, GetColor(255, 255, 255), "SLv%d", sBuffLevel);
+
+	DrawBox(SBAR_X, SBAR_Y, SBAR_X1 + 200, SBAR_Y1 + 20, GetColor(255, 255, 255), FALSE);									//枠
+
+	DrawBox(SGAUGE_X, SGAUGE_Y, SGAUGE_X1 + 200 * sBuffPoint / MAX_BUFF, SGAUGE_Y1 + 20, GetColor(0, 255, 0), TRUE);	//ゲージ
+
+}
+
 //操作説明
 void UI::PlayGuide()
 {
@@ -36,8 +56,12 @@ void UI::PlayGuide()
 }
 
 //更新
-void UI::Update(CastleManager* _castlemanager)
+void UI::Update(CastleManager* _castlemanager, ItemManager* _itemmanager, BuffManager* _buffmanager)
 {
+	pBuffPoint = _itemmanager->Get_P_Count();
+	sBuffPoint = _itemmanager->Get_S_Count();
+	pBuffLevel = _buffmanager->GetPowerLevel();
+	sBuffLevel = _buffmanager->GetSpeedLevel();
 	CastleDurability = _castlemanager->Get_Durability(0);		//拠点の体力をセットする
 }
 
@@ -45,5 +69,6 @@ void UI::Update(CastleManager* _castlemanager)
 void UI::Draw()
 {
 	Get_CastleDurability();
+	Get_BuffPoint();
 	PlayGuide();
 }

--- a/Source/Ui.h
+++ b/Source/Ui.h
@@ -21,7 +21,8 @@ private:
 	static const int HPGAUGE_Y = 10;
 	static const int HPGAUGE_X1 = 50;			//バーのｘ終点
 	static const int HPGAUGE_Y1 = 10;	
-	static const int MAX_DURABILTY = 100;		//拠点最大体力
+	static const int MAX_DURABILTY = 100;		//メイン拠点最大体力
+	static const int MAX_SABDURABILTY = 50;	//サブ拠点最大体力
 
 	static const int PMOJI_X = 1150;			//文字のｘ
 	static const int PMOJI_Y = 760;
@@ -56,9 +57,9 @@ private:
 	int Color;						//色
 
 public:
-	void Get_CastleDurability();		//拠点の体力を受け取る
+	void Get_CastleDurability();		//メイン拠点の体力UI
 	void Get_BuffPoint();
-	void PlayGuide();					//プレイヤーのガイド
+	void Get_SubCastleDurability();		//サブ拠点の体力UI 
 	void Update(CastleManager* _castlemanager, ItemManager* _itemmanager, BuffManager* _buffmanager);		//更新処理
 	void Draw();						//描画処理
 };

--- a/Source/Ui.h
+++ b/Source/Ui.h
@@ -2,8 +2,12 @@
 #define _UI_H
 
 #include "CastleManager.h"
+#include "ItemManager.h"
+#include "BuffManager.h"
 
 class CastleManager;
+class ItemManager;
+class BuffManager;
 class UI
 {
 private:
@@ -19,14 +23,43 @@ private:
 	static const int HPGAUGE_Y1 = 10;	
 	static const int MAX_DURABILTY = 100;		//拠点最大体力
 
+	static const int PMOJI_X = 1150;			//文字のｘ
+	static const int PMOJI_Y = 760;
+	static const int PBAR_X = 1200;				//枠のｘ始点
+	static const int PBAR_Y = 760;
+	static const int PBAR_X1 = 1200;			//枠のｘ終点
+	static const int PBAR_Y1 = 760;
+	static const int PGAUGE_X = 1200;			//バーのｘ始点
+	static const int PGAUGE_Y = 760;
+	static const int PGAUGE_X1 = 1200;			//バーのｘ終点
+	static const int PGAUGE_Y1 = 760;
+
+	static const int SMOJI_X = 1150;			//文字のｘ
+	static const int SMOJI_Y = 800;
+	static const int SBAR_X = 1200;				//枠のｘ始点
+	static const int SBAR_Y = 800;
+	static const int SBAR_X1 = 1200;			//枠のｘ終点
+	static const int SBAR_Y1 = 800;
+	static const int SGAUGE_X = 1200;			//バーのｘ始点
+	static const int SGAUGE_Y = 800;
+	static const int SGAUGE_X1 = 1200;			//バーのｘ終点
+	static const int SGAUGE_Y1 = 800;
+
+	const float MAX_BUFF = 10.0;				//バフゲージの最大数
+
 	int percent;					//パーセント
 	int CastleDurability;			//拠点の体力
+	int pBuffPoint;					//pアイテムのゲージ上昇用
+	int sBuffPoint;					//sアイテムのゲージ上昇用
+	int pBuffLevel;					//pアイテム獲得時のバフレベル
+	int sBuffLevel;					//sアイテム獲得時のバフレベル
 	int Color;						//色
 
 public:
 	void Get_CastleDurability();		//拠点の体力を受け取る
+	void Get_BuffPoint();
 	void PlayGuide();					//プレイヤーのガイド
-	void Update(CastleManager* _castlemanager);		//更新処理
+	void Update(CastleManager* _castlemanager, ItemManager* _itemmanager, BuffManager* _buffmanager);		//更新処理
 	void Draw();						//描画処理
 };
 


### PR DESCRIPTION
## 概要
バフアイテムのUIを追加と操作説明を削除

## 技術的変更点概要
pアイテムの取得時に加算されるポイントをUIで表示
sアイテムの取得時に加算されるポイントをUIで表示
pバフレベルの表示
sバフレベルの表示

## 今回保留した項目とTODOリスト
サブ拠点の体力UIを形だけ追加ので後は座標とかの
サブ拠点の体力を値を受け取れば終了します