### PR TITLE
[fix] Fream関連 define.hを適用 スペルミス修正

### DIFF
--- a/Source/EventManager.cpp
+++ b/Source/EventManager.cpp
@@ -30,7 +30,7 @@ EventManager::~EventManager() {
 void EventManager::SpawnEvent() {
 	waitCount++;
 
-	if (waitCount < FREAM * eventWaitTime) {// フレーム数 * 秒 = 待機時間　待機時間を超えても前のイベントが実行中なら実行しない
+	if (waitCount < FRAME * eventWaitTime) {// フレーム数 * 秒 = 待機時間　待機時間を超えても前のイベントが実行中なら実行しない
 
 		if (Event == NULL) {//NULL(何もイベントが発生していない)時に生成
 

--- a/Source/EventManager.h
+++ b/Source/EventManager.h
@@ -1,6 +1,7 @@
 #ifndef _EVENTMANAGER_H
 #define _EVENTMANAGER_H
 
+#include "Define.h"
 #include "DarknessEvent.h"
 
 class BaseEvent;
@@ -16,8 +17,6 @@ private:
 	static const int ACTIVEEVENT_HARD = 30;
 
 	static const int EVENT_TYPES = 2;			//イベントの種類
-
-	static const int FREAM = 60;				//フレームレート
 
 	int eventWaitTime;		//難易度よって変わるイベントの発生間隔
 


### PR DESCRIPTION
## 概要

define.hの適用 定数FERAMの削除、freamのスペルミス修正

## 技術的変更点概要

## 今回保留した項目とTODOリスト

## その他
