### PR TITLE
[fix] Fream関連 define.hの適用とスペルミスの修正、列挙型PHASEの宣言を省略、nowPhaseの型を変更

### DIFF
--- a/Source/DarknessEvent.h
+++ b/Source/DarknessEvent.h
@@ -3,24 +3,25 @@
 
 #include <DxLib.h>
 #include "BaseEvent.h"
+#include "Define.h"
+
 
 class DarknessEvent : public virtual BaseEvent {
 private:
-	static const int FREAM = 60; //フレーム数
 
-	static const int MAX_DARKNESSTIME = 15 * FREAM;	//暗闇時間　秒 * フレーム数
+	static const int MAX_DARKNESSTIME = 15 * FRAME;	//暗闇時間　秒 * フレーム数
 
 	static const int MAX_OPACITY = 255;		//最大不透明度
 
 	enum PHASE {
-		PHASE_START = 0,	//開始フェーズ　不透明度をあげる
-		PHASE_DARK = 1,		//維持フェーズ　不透明度を維持
-		PHASE_END = 2		//終了フェーズ　不透明度を下げる
+		PHASE_START,	//開始フェーズ　不透明度をあげる
+		PHASE_DARK,		//維持フェーズ　不透明度を維持
+		PHASE_END		//終了フェーズ　不透明度を下げる
 	};
 
-	int darkCount;		//経過時間
+	PHASE nowPhase;		//現在のフェーズ
 
-	int nowPhase;		//現在のフェーズ
+	int darkCount;		//経過時間
 
 	int opacity;		//不透明度
 


### PR DESCRIPTION
## 概要

define.hの適用、定数FRAMEの削除
スペルミス修正、列挙型の宣言省略
nowPhaseの型修正

## 技術的変更点概要

## 今回保留した項目とTODOリスト
画像クラスの使用

## その他
ついに動作確認したのでDarknessEventは画像クラスの適用をすれば完成