### PR TITLE
[fix] 待機カウントの初期化と生成のif文の不等号の向きを間違えていたので修正

### DIFF
--- a/Source/EventManager.cpp
+++ b/Source/EventManager.cpp
@@ -4,6 +4,7 @@
 EventManager::EventManager(int level) {
 
 	Event = NULL;		//イベントの初期化
+	waitCount = 0;		//カウント初期化
 
 	switch (level)				//引数(0～2)で難易度別の生成数を設定
 	{
@@ -30,7 +31,7 @@ EventManager::~EventManager() {
 void EventManager::SpawnEvent() {
 	waitCount++;
 
-	if (waitCount < FRAME * eventWaitTime) {// フレーム数 * 秒 = 待機時間　待機時間を超えても前のイベントが実行中なら実行しない
+	if (waitCount >= FRAME * eventWaitTime) {// フレーム数 * 秒 = 待機時間　待機時間を超えても前のイベントが実行中なら実行しない
 
 		if (Event == NULL) {//NULL(何もイベントが発生していない)時に生成
 


### PR DESCRIPTION
## 概要
待機カウントが初期化されていなかったので修正
生成(カウントによって生成されるところ)のif文の不等号の向きを間違えていたので修正

## 技術的変更点概要
上記の通り

## 今回保留した項目とTODOリスト
他のイベントが完成次第生成に組み込む

## その他
一応動作確認はしました