### PR TITLE
ItemManager

### DIFF
--- a/Source/ItemManager.cpp
+++ b/Source/ItemManager.cpp
@@ -96,17 +96,17 @@ void ItemManager::Draw() {
 }
 
 void ItemManager::SpawnItem(float _ex,float _ey) {
-	bool isSpawn = false;	//生成判定フラグ
+	bool isSpawn = false;									//生成判定フラグ
+	int spawnPercent = GetRand(ITEM_GENERATION_RANDMAX);	//生成確率
+
+	//50未満の場合生成判定フラグをtrueにする
+	if (spawnPercent % ITEM_RATEDATA <= ITEM_GENERATION_RATE) {
+		isSpawn = true;
+	}
 
 	for (int i = 0; i < MAX_ITEM_NUM; i++) {
 		//items[i]が空の場合
 		if (items[i] == nullptr) {
-			int spawnPercent = GetRand(ITEM_GENERATION_RANDMAX);	//生成確率
-
-			//50未満の場合生成判定フラグをtrueにする
-			if (spawnPercent < ITEM_GENERATION_RATE) {
-				isSpawn = true;
-			}
 
 			//生成判定フラグがtrueの場合
 			if (isSpawn == true) {
@@ -121,6 +121,8 @@ void ItemManager::SpawnItem(float _ex,float _ey) {
 				if (spawnType == static_cast<int>(eItem::Speed)) {
 					items[i] = new Item_S(_ex, _ey, 16, 16, eItem::Speed);
 				}
+
+				return;
 			}
 
 			break;

--- a/Source/ItemManager.h
+++ b/Source/ItemManager.h
@@ -13,7 +13,8 @@ class ItemManager final {
 private:
 	static const int MAX_ITEM_NUM = 50;			//アイテムの画面上最大生成数
 	const int ITEM_GENERATION_RANDMAX = 100;	//アイテムの生成用RANDMAX
-	const int ITEM_GENERATION_RATE = 100;		//アイテムの生成率
+	const int ITEM_RATEDATA = 10;				//アイテムの生成率関連のデータ
+	const int ITEM_GENERATION_RATE = 10;			//アイテムの生成率
 	const int ITEM_TYPE_NUM = 2;				//アイテムの種類の数
 
 	BaseItem* items[MAX_ITEM_NUM];	//アイテム


### PR DESCRIPTION
## 概要
* **[update]** 生成するかの判定処理を修正
* **[fix]** 生成率が本来の想定と違うバグを修正
## 技術的変更点概要
* 生成するかの判定処理を修正
```c++
    if (spawnPercent % ITEM_RATEDATA <= ITEM_GENERATION_RATE) {
        isSpawn = true;
    }
```
* 生成率が本来の想定と違うバグを修正
``for文から処理を除外して、関数が呼ばれた初回のみに変更``
## 今回保留した項目とTODOリスト
### TODO
* **バランス調整**
## その他
前々回参照
[前々回](https://github.com/Stardust-Seed/Reitaisai2020_Autumn/pull/159)
