### PR TITLE
[update]爆弾画像のImageクラスの適応とseクラスの適応

### DIFF
--- a/Source/BaseBomb.cpp
+++ b/Source/BaseBomb.cpp
@@ -2,25 +2,15 @@
 #include "BaseBomb.h"
 
 //コンストラクタ
-BaseBomb::BaseBomb(int _power, eBombType _btype)
+BaseBomb::BaseBomb(int _power, int _speed, eBombType _bombType)
 {
-	//SRand;								//乱数の初期化
-	//type = GetRand(MAX_TYPE - 1);		//種類の乱数
-	type = bomb;
-	if (type == bomb)
-	{
-		power = _power;
-	}
-
-	if (type == fakebomb)
-	{
-		power = _power;
-	}
-	
+	SRand;
+	speed = _speed;
+	power = _power;
+	type = _bombType;
 	
 	direction = GetRand(3);					//方向の乱数
-	//direction = 3;
-	speed = 3;
+	
 	countdown = COUNTMAX;						//カウントダウンのセット
 	
 	isSpown = false;
@@ -28,6 +18,7 @@ BaseBomb::BaseBomb(int _power, eBombType _btype)
 	isXplosion = false;							//初期状態
 	isTrigger = false;
 	isFakeTrigger = false;
+	isCount == false;
 
 	if (direction == DIRECTIONLEFT)			//左
 	{
@@ -62,11 +53,6 @@ BaseBomb::~BaseBomb()
 //爆弾生成
 void BaseBomb::SpawnBomb()
 {
-
-	//DrawFormatString(10, 300, GetColor(255, 255, 255), "type%d", type);
-	
-	//DrawFormatString(10, 300, GetColor(255, 255, 255), "type%d", power);
-
 	//真
 	if (type == bomb)
 	{
@@ -127,24 +113,36 @@ void BaseBomb::JudgeTrigger()
 	//爆弾のタイマー
 	if (speed == 0)
 	{
-		DrawFormatString(10, 150, GetColor(255, 255, 255), "%d", countdown / FRAME);	//表示
-		if (countdown <= FRAME) {								//残り一秒以下は割り算の結果0になるため、表示タイミングの調整
-			isXplosion = true;									//フラグ切替
-		}
+		isCount = true;
+		if (isCount == true)
+		{
+			DrawFormatString(10, 150, GetColor(255, 255, 255), "%d", countdown / FRAME);	//表示
 
-		if (countdown >= 0) {									//表示されているタイマーを0にしたいのでカウントダウン自体は0になるまで動かす
-			countdown -= 1;										//カウントダウン
+			if (countdown <= FRAME) {								//残り一秒以下は割り算の結果0になるため、表示タイミングの調整
+				isXplosion = true;                                  //フラグ切替
+				isCount = false;
+			}
+
+			if (countdown >= 0) {									//表示されているタイマーを0にしたいのでカウントダウン自体は0になるまで動かす
+				countdown -= 1;										//カウントダウン
+			}
 		}
+	}
+
+	if (isCount == false)
+	{
+		
 	}
 
 	if (type == bomb)
 	{
 		if (isXplosion == true)			//爆発する
 		{
-			//DrawString(700, 300, "爆発", GetColor(255, 255, 255));
+			//SE::Instance()->PlaySE(SE_bomb);		//爆発の音
 			isTrigger = true;
 			isXplosion = false;
 			isSpown = false;
+			
 		}
 	}
 
@@ -152,12 +150,13 @@ void BaseBomb::JudgeTrigger()
 	{
 		if (isXplosion == true)			//爆発する
 		{
-			//DrawString(600, 300, "偽爆発", GetColor(255, 255, 255));
-			isFakeTrigger = true;
+			isTrigger = true;
 			isXplosion = false;
+			//isCount = false;
 			isFakeSpown = false;
 		}
 	}
 }
+
 
 

--- a/Source/BaseBomb.h
+++ b/Source/BaseBomb.h
@@ -2,14 +2,16 @@
 #define _BASEBOMB_H
 
 #include "Define.h"
+#include "BaseEvent.h"
+#include "SE.h"
 
 	enum eBombType
 	{
-		bomb,
-		fakebomb,
+		bomb = 1,
+		fakebomb = 2,
 	};
 	
-	class BaseBomb
+	class BaseBomb : public virtual BaseEvent
 	{
 	protected:
 		const float BOMB_SPOWNUPDOWNX = GAME_WIDTH / 2 - 25;				//ã‰ºx
@@ -44,21 +46,21 @@
 		bool isFakeTrigger;				//”š”­‚µ‚Ä‚é‚©‚µ‚Ä‚È‚¢‚©(‹U)
 		bool isSpown;					//”š’e‚Ì¶¬‚µ‚½‚©‚Ç‚¤‚©
 		bool isFakeSpown;				//”š’e‚Ì¶¬‚µ‚½‚©‚Ç‚¤‚©(‹U)
+		bool isCount;					//ƒJƒEƒ“ƒgƒ_ƒEƒ“‚ğ‰æ‘œ‚Å•\¦‚³‚¹‚é‚½‚ß
 
 	public:
 		BaseBomb() {}
 		~BaseBomb();
-		BaseBomb(int _power, eBombType _btype);
+		BaseBomb(int _power, int _speed, eBombType _bombType);
 
 		void SpawnBomb();								//”š’e‚Ì¶¬
 		void JudgeTrigger();							//”š”­‚µ‚½‚©‚Ì”»’è
 		void Move();									//”š’e‚Ì—‰º
-		void SetIsTrigger(bool _isTrigger) { isTrigger = _isTrigger; }
 
 		int GetPower() { return power; }							
-		bool GetIsTrigger() { return isTrigger; }
-		virtual void Update() = 0;
-		virtual void Draw() = 0;
+		bool GetIsTriggerFlg() { return isTrigger; }
+		virtual void Update() {}
+		virtual void Draw() {}
 
 	};
 #endif // !_BASEBOMB_H

--- a/Source/Bomb.cpp
+++ b/Source/Bomb.cpp
@@ -1,13 +1,10 @@
 #include <DxLib.h>
 #include "Bomb.h"
-
-Bomb::Bomb(int _power, eBombType _btype)
-	: BaseBomb(_power, _btype)
+#include "Image.h"
+Bomb::Bomb(int _power, int _speed, eBombType _bombType)
+	: BaseBomb(_power, _speed, _bombType)
 {
 	gBomb = LoadGraph("res/Image/bomb.png");
-	LoadDivGraph("res/Image/ex.png", 6, 6, 1, 100, 100, GHandle);
-
-	_power = BOMBDAMAGE;
 };
 
 //”š”­‚µ‚½‚Æ‚«‚Ìˆ—
@@ -15,14 +12,7 @@ void Bomb::DamageMotion()
 {
 	if (isTrigger == true)
 	{ 
-		//DrawFormatString(700, 170, GetColor(255, 255, 255), "%d", damage);
-		//DrawString(700, 350, "–{•¨", GetColor(255, 255, 255));
-		m_frameIndex++;
-		m_frameIndex %= 12;
-
-		int motion_bomb = act_frameIndex[m_frameIndex];
-		DrawGraph(x, y, GHandle[motion_bomb], TRUE);
-		DeleteGraph(GHandle[motion_bomb]);
+		Animation();
 		isTrigger = false;
 	}
 }
@@ -42,7 +32,49 @@ void Bomb::Draw()
 {
 	if (isSpown == true)
 	{
+		//DrawString(700, 350, "–{•¨", GetColor(255, 255, 255));
 		DrawGraph(x, y, gBomb, TRUE);
+	}
+}
+
+void Bomb::Animation()
+{
+	m_frameIndex++;
+
+	if (act_frameIndex[m_frameIndex] == 0)
+	{
+		DrawGraph(x, y, Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 0), TRUE);
+		DeleteGraph(Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 0));
+	}
+
+	if (act_frameIndex[m_frameIndex] == 1)
+	{
+		DrawGraph(x, y, Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 1), TRUE);
+		DeleteGraph(Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 1));
+	}
+
+	if (act_frameIndex[m_frameIndex] == 2) 
+	{
+		DrawGraph(x, y, Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 2), TRUE);
+		DeleteGraph(Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 2));
+	}
+
+	if (act_frameIndex[m_frameIndex] == 3)
+	{
+		DrawGraph(x, y, Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 3), TRUE);
+		DeleteGraph(Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 3));
+	}
+
+	if (act_frameIndex[m_frameIndex] == 4)
+	{
+		DrawGraph(x, y, Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 4), TRUE);
+		DeleteGraph(Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 4));
+	}
+
+	if (act_frameIndex[m_frameIndex] == 5)
+	{
+		DrawGraph(x, y, Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 5), TRUE);
+		DeleteGraph(Image::Instance()->GetGraph(eImageType::Gpicture_Explosion, 5));
 	}
 }
 

--- a/Source/Bomb.h
+++ b/Source/Bomb.h
@@ -3,17 +3,19 @@
 
 #include "BaseBomb.h"
 
-class Bomb :public BaseBomb {
+class Bomb : public virtual BaseBomb {
 private:
 	const int BOMBDAMAGE = 10;
 
 	int gBomb;
 	int m_Image;	        // 画像ハンドル
-	int GHandle[6];      // 格納用画像ハンドル
+	int GHandle[6];         // 格納用画像ハンドル
 	int act_frameIndex[12] = { 0, 1, 2, 2, 3, 4, 5, 4, 3, 2, 1, 0};    // 表示する番号
 	int m_frameIndex = 0;
 public:
-	Bomb(int _power, eBombType _btype);
+	Bomb() = default;
+	Bomb(int _power, int _speed, eBombType _bombType);
+	void Animation();
 	void DamageMotion();
 	void Update();
 	void Draw();

--- a/Source/FakeBomb.cpp
+++ b/Source/FakeBomb.cpp
@@ -1,12 +1,11 @@
 #include <DxLib.h>
 #include "FakeBomb.h"
 
-FakeBomb::FakeBomb(int _power, eBombType _btype)
-	: BaseBomb(_power, _btype)
+FakeBomb::FakeBomb(int _power, int _speed, eBombType _bombType)
+	: BaseBomb(_power, _speed, _bombType)
 {
 	fBomb = LoadGraph("res/Image/bomb.png");
 	fAction = LoadGraph("res/Image/fake.png");
-	_power = 0;
 	isFakeAction = false;
 };
 
@@ -14,13 +13,13 @@ FakeBomb::FakeBomb(int _power, eBombType _btype)
 void FakeBomb::FakeMotion()
 {
 	//‹U”š’e‚ª‹N“®
-	if (isFakeTrigger == true)
+	if (isTrigger == true)
 	{
 		isFakeAction = true;
 		if (isFakeAction == true)
 		{
-			DrawGraph(x, y + 400, fAction, TRUE);
-			isFakeTrigger = false;
+			DrawGraph(x, y, fAction, TRUE);
+			isTrigger = false;
 			isFakeAction = false;
 		}
 
@@ -29,8 +28,6 @@ void FakeBomb::FakeMotion()
 			DeleteGraph(fAction);
 		}
 
-		power = 0;
-		//DrawFormatString(700, 190, GetColor(255, 255, 255), "%d", damage);
 		//DrawString(700, 370, "‹U•¨", GetColor(255, 255, 255));
 	}
 }
@@ -50,6 +47,7 @@ void FakeBomb::Draw()
 {
 	if (isFakeSpown == true)
 	{
+		//DrawString(700, 370, "‹U•¨", GetColor(255, 255, 255));
 		DrawGraph(x, y, fBomb, TRUE);
 	}
 }

--- a/Source/FakeBomb.h
+++ b/Source/FakeBomb.h
@@ -3,14 +3,15 @@
 
 #include "BaseBomb.h"
 
-class FakeBomb:public BaseBomb
+class FakeBomb : public virtual BaseBomb
 {
 private:
 	int fBomb;
 	int fAction;
 	bool isFakeAction;
 public:
-	FakeBomb(int _power, eBombType _btype);
+	FakeBomb() = default;
+	FakeBomb(int _power, int _speed, eBombType _bombType);
 	void FakeMotion();
 	void Update();
 	void Draw();


### PR DESCRIPTION
## 概要

処理の追加

## 技術的変更点概要

Imageクラスで爆発の画像を適応
SEクラスで爆発の音を適応
## 今回保留した項目とTODOリスト
フェイク爆弾の画像とSEを探す
それが探し終えて適応出来たらEventManagerで爆弾を呼び出す。
あとカウントダウンの数字も画像で表示させようと思ってる

## その他
自分の環境でEventManagerから正常に爆弾を呼び出す処理は出来てます。
後ほど仕様書を修正する