### PR TITLE
[update] 終了のSE鳴らすif文の表記変更 暗闇維持の時間調整

### DIFF
--- a/Source/DarknessEvent.cpp
+++ b/Source/DarknessEvent.cpp
@@ -29,7 +29,8 @@ void DarknessEvent::Update() {
 	if (nowPhase == PHASE_DARK) {								//維持フェーズ
 		if (darkCount <= MAX_DARKNESSTIME) {
 			darkCount++;									//カウント加算
-			if (darkCount == 14 * FRAME) {
+
+			if (darkCount == MAX_DARKNESSTIME - FRAME) {	//維持フェーズ終了一秒前にSEが鳴るように(SEのタイミング調整)
 				SE::Instance()->PlaySE(SE_DarknessEnd);
 			}
 		}

--- a/Source/DarknessEvent.h
+++ b/Source/DarknessEvent.h
@@ -9,7 +9,7 @@
 class DarknessEvent : public virtual BaseEvent {
 private:
 
-	static const int MAX_DARKNESSTIME = 15 * FRAME;	//暗闇時間　秒 * フレーム数
+	static const int MAX_DARKNESSTIME = 10 * FRAME;	//暗闇時間　秒 * フレーム数
 
 	static const int MAX_OPACITY = 255;		//最大不透明度
 


### PR DESCRIPTION
## 概要
ソースの調整
暗闇維持時間を短くしました

## 技術的変更点概要
終了のSEを鳴らすタイミングのif文の14を暗闇維持時間 - 1に変更

## 今回保留した項目とTODOリスト
多分ない、あったとしても画像の調整だと思う
## その他
