### PR TITLE
[update]プレイヤー処理を改変。ベースプレイヤーで完結出来るように

### DIFF
--- a/Source/BasePlayer.cpp
+++ b/Source/BasePlayer.cpp
@@ -74,15 +74,11 @@ void BasePlayer::Draw()
 		Image::Instance()->TransparentGraph(pos.x, pos.y, Image::Instance()->GetGraph(eImageType::Gpicture_Player, graphNo), 255, true);
 	}
 
-	DrawFormatString(200, 200, GetColor(255, 255, 255), "GraphNo%d", graphNo);
-
 }
 void BasePlayer::Update(EnemyManager* _eManager,BuffManager* _bManager)
 {
     power *= _bManager->GetPowerBuff();   //バフによる攻撃力増加
 	speed *= _bManager->GetSpeedBuff();   //バフによるスピード増加
-
-	AbilityCount();    //スキル回数表示
 
 	//スタン状態でない時
 	if (isStan == 0) {
@@ -93,8 +89,6 @@ void BasePlayer::Update(EnemyManager* _eManager,BuffManager* _bManager)
 
 		/***咲夜のスキル処理***/
 		if (Get_isAbility() == true && playerType == SAKUYA_Ability) {
-
-			AbilityClock();                    //スキルタイマーの表示
 
 			if (abilityTimer >= 0 && countDown <= 0) {	    //表示されているタイマーを0にしたいのでカウントダウン自体は0になるまで動かす
 				abilityTimer -= 1;
@@ -245,18 +239,6 @@ void BasePlayer::Ability()
 			abilityCount -= 1;
 		}
 	}
-}
-void BasePlayer::AbilityCount()
-{
-
-	DrawFormatStringToHandle(100, 800, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_48_3(), "%d", abilityCount);
-
-}
-void BasePlayer::AbilityClock()
-{
-
-	DrawFormatStringToHandle(100, 700, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_48_3(), "%d", abilityTimer);
-
 }
 //プレイヤーの移動処理
 void BasePlayer::Move()

--- a/Source/BasePlayer.cpp
+++ b/Source/BasePlayer.cpp
@@ -8,7 +8,7 @@
 #include"EnemyManager.h"
 #include"Image.h"
 
-BasePlayer::BasePlayer(PlayerType _pType)
+BasePlayer::BasePlayer(int _pType)
 {
 	pos = VGet(PLAYER_LEFTPOS, PLAYER_LEFTRIGHTPOS, 0);
 	vPos = VGet(0, 0, 0);

--- a/Source/BasePlayer.h
+++ b/Source/BasePlayer.h
@@ -3,6 +3,7 @@
 
 #include"Object.h"
 #include"DxLib.h"
+#include "FontHandle.h"
 
 class BulletManager;
 class BuffManager;
@@ -38,9 +39,6 @@ class BasePlayer :public virtual Object
 	//キャラクター選択
 	PlayerType playerType;
 
-	//キャラのアビリティ
-	AbilityType abilityType;
-
 
 protected:
 
@@ -59,6 +57,13 @@ protected:
 
 	const int ANIMETION_MAX = 3;            //アニメーションの最大数
 	const int ANIMETION_SPEED = 10;         //アニメーションのスピード
+
+	//咲夜スキル用
+	const int STOPTIME = 5;         //時止めスキルの時間
+	int abilityTimer;               //スキル発動時間
+	int countDown;                  //スキルタイマーのカウントダウンに使用
+
+	//フランスキル用
 
 	int speed;		                //プレイヤーの移動速度
 	int power;		                //プレイヤーの攻撃力
@@ -98,7 +103,7 @@ public:
 	bool ClisionHit(float mx, float my, float mw, float mh,
 		float ox, float oy, float ow, float oh);
 	BasePlayer() {}
-	BasePlayer( PlayerType _pType, AbilityType _pAbility);		   //コンストラクタ
+	BasePlayer( PlayerType _pType);		   //コンストラクタ
 	~BasePlayer();         //デストラクタ
 	void Draw();           //描画処理
 
@@ -112,6 +117,10 @@ public:
 	void Move_RIGHT();     //→移動処理
 	void Attack();         //攻撃処理
 	void Animation();      //アニメーション
+	void Ability();        //スキル処理
+	void AbilityCount();   //スキル回数表示
+
+	void AbilityClock();   //咲夜スキルタイマー描画処理
 
 	//スタン処理
 	void Stan();           
@@ -138,7 +147,7 @@ public:
 	
 	void SetBulletManager(BulletManager* bullet) { bulletManager = bullet; }//bulletManagerのアドレスを取得
 
-	AbilityType Get_AbilityType() { return abilityType; }  //スキルタイプのゲッター
+	PlayerType Get_AbilityType() { return playerType; }  //スキルタイプのゲッター
 };
 
 

--- a/Source/BasePlayer.h
+++ b/Source/BasePlayer.h
@@ -118,9 +118,6 @@ public:
 	void Attack();         //攻撃処理
 	void Animation();      //アニメーション
 	void Ability();        //スキル処理
-	void AbilityCount();   //スキル回数表示
-
-	void AbilityClock();   //咲夜スキルタイマー描画処理
 
 	//スタン処理
 	void Stan();           
@@ -140,14 +137,17 @@ public:
 	float Get_height() { return height; }                   //heightゲッター
 
 	int  Get_power() { return power; }                      //攻撃力ゲッター
-	int  Get_abilityCount() { return abilityCount; }              //スキル時間のゲッター
 
 	bool Get_isStan() { return isStan; }                    //スタン状態ゲッター
-	bool Get_isAbility() { return isAbility; }           //スキルのActiveのゲッター
+	bool Get_isAbility() { return isAbility; }              //スキルのActiveのゲッター
 	
 	void SetBulletManager(BulletManager* bullet) { bulletManager = bullet; }//bulletManagerのアドレスを取得
 
-	int Get_AbilityType() { return playerType; }  //スキルタイプのゲッター
+	int Get_AbilityType() { return playerType; }            //スキルタイプのゲッター
+
+	
+	int Get_AbilityCount() { return abilityCount; }         //スキル回数のゲッター
+	int Get_abilityClock() { return abilityTimer; }        //スキル時間のゲッター
 };
 
 

--- a/Source/BasePlayer.h
+++ b/Source/BasePlayer.h
@@ -37,7 +37,7 @@ class BasePlayer :public virtual Object
 	BaseEnemy* baseEnemy;
 
 	//キャラクター選択
-	PlayerType playerType;
+	int playerType;
 
 
 protected:
@@ -103,7 +103,7 @@ public:
 	bool ClisionHit(float mx, float my, float mw, float mh,
 		float ox, float oy, float ow, float oh);
 	BasePlayer() {}
-	BasePlayer( PlayerType _pType);		   //コンストラクタ
+	BasePlayer( int _pType);		   //コンストラクタ
 	~BasePlayer();         //デストラクタ
 	void Draw();           //描画処理
 
@@ -147,7 +147,7 @@ public:
 	
 	void SetBulletManager(BulletManager* bullet) { bulletManager = bullet; }//bulletManagerのアドレスを取得
 
-	PlayerType Get_AbilityType() { return playerType; }  //スキルタイプのゲッター
+	int Get_AbilityType() { return playerType; }  //スキルタイプのゲッター
 };
 
 


### PR DESCRIPTION
## 概要

キャラクターの違いによって変化する部分をBasePlayerで切り替えがされるように。
咲夜とフランでファイルを分けてまで行う処理がなかったので、BasePlayerで完結するように。
動作確認済。

## 技術的変更点概要

キャラ選択画面で選択されたキャラがゲーム画面でロジカルします。
別に変更点じゃないなこれ

## 今回保留した項目とTODOリスト

弾の画像とSE

## その他

* レビュワーに対する注意点 (ここはこういう風に思ったけどこういう風に実装した、ここはこうしようと思ったんだけどこういう悩みがありやめた、など注意点があれば)
