### PR TITLE
[update]キャラセレクト画面の選択項目の色が変わるように

### DIFF
--- a/Source/CharaSelect.cpp
+++ b/Source/CharaSelect.cpp
@@ -8,6 +8,11 @@ CharaSelect::CharaSelect(ISceneChanger* _sceneChanger, Parameter* _parameter) :B
 	//最初は咲夜が選択されている状態
 	charaSelect = select_SAKUYA;
 
+	//最初は咲夜が選択されている状態
+	select_Sakuya= 0;
+	select_Fran = 0;
+	select_Menu = 0;
+
 	//色
 	color = GetColor(0, 0, 255);
 
@@ -56,6 +61,25 @@ void CharaSelect::Update()
 		}
 	}
 
+	if (charaSelect == select_SAKUYA)
+	{
+		select_Sakuya = 3;
+		select_Fran = 0;
+		select_Menu = 0;
+	}
+	else if (charaSelect == select_FRAN)
+	{
+		select_Fran = 1;
+		select_Sakuya = 0;
+		select_Menu = 0;
+	}
+	else
+	{
+		select_Menu = 2;
+		select_Sakuya = 0;
+		select_Fran = 0;
+	}
+
 }
 
 /*描画処理*/
@@ -91,17 +115,18 @@ void CharaSelect::Draw_Waku()
 }
 void CharaSelect::Draw_CharaName()
 {
-	//枠
-	//咲夜
-	DrawRotaGraph(690,725,0.6,0.0,Image::Instance()->GetGraph(eImageType::UI_CursorFrame, 3),TRUE);
+	//咲夜枠
+	DrawRotaGraph(690,725,0.6,0.0,Image::Instance()->GetGraph(eImageType::UI_CursorFrame, select_Sakuya),TRUE);
+	//スキル枠
 	DrawExtendGraph(125, 200, 530, 600, Image::Instance()->GetGraph(eImageType::UI_CursorFrame, 0), TRUE);
 
-	//フラン
-	DrawRotaGraph(1250, 725, 0.6, 0.0, Image::Instance()->GetGraph(eImageType::UI_CursorFrame, 1), TRUE);
+	//フラン枠
+	DrawRotaGraph(1250, 725, 0.6, 0.0, Image::Instance()->GetGraph(eImageType::UI_CursorFrame, select_Fran), TRUE);
+	//スキル枠
 	DrawExtendGraph(1410, 200, 1800, 600, Image::Instance()->GetGraph(eImageType::UI_CursorFrame, 0), TRUE);
 
-	//メニュー
-	DrawRotaGraph(975, 925, 0.6, 0.0, Image::Instance()->GetGraph(eImageType::UI_CursorFrame, 0), TRUE);
+	//メニュー枠
+	DrawRotaGraph(975, 925, 0.6, 0.0, Image::Instance()->GetGraph(eImageType::UI_CursorFrame, select_Menu), TRUE);
 
 	/**描画 前**/
 	//キャラクター名の表示

--- a/Source/CharaSelect.h
+++ b/Source/CharaSelect.h
@@ -25,6 +25,9 @@ class CharaSelect :public BaseScene {
 private:
 
 	int charaSelect;                    //選択したキャラタイプ
+	int select_Sakuya;                  //項目枠：咲夜
+	int select_Fran;                    //項目枠：フラン
+	int select_Menu;                    //項目枠：メニュー
 
 	int color;    //色
 


### PR DESCRIPTION
## 概要

キャラセレクト画面で、選択している項目の色が変わるように。
咲夜：青　フラン：赤　メニュー：緑

## 技術的変更点概要

## 今回保留した項目とTODOリスト

キャラのステータスを★マークで表そうかなって

例：　咲夜　スピード：★★★★　パワー：★★　みたいな

## その他

* レビュワーに対する注意点 (ここはこういう風に思ったけどこういう風に実装した、ここはこうしようと思ったんだけどこういう悩みがありやめた、など注意点があれば)
