### PR TITLE
[update]色々変更

### DIFF
--- a/Source/CastleManager.cpp
+++ b/Source/CastleManager.cpp
@@ -19,7 +19,7 @@ CastleManager::CastleManager() {
 			}
 			else         //ƒTƒu‹’“_
 			{
-				durability = 35;
+				durability = 25;
 				Castles[i] = new SubCastle(durability, i);    //¶¬ˆ—
 			}
 			activeCountFlg[i] = true;

--- a/Source/GameClear.cpp
+++ b/Source/GameClear.cpp
@@ -17,8 +17,8 @@ GameClear::GameClear(ISceneChanger* _sceneChanger, Parameter* _parameter)
 
 /*更新処理*/
 void GameClear::Update() {
-	Select();
 	Move();
+	Select();
 }
 
 /*描画処理*/
@@ -46,7 +46,8 @@ void GameClear::Draw() {
 	SetDrawBlendMode(DX_BLENDMODE_PMA_ALPHA, alpha);
 
 	//ゲームクリア表示
-	DrawStringToHandle(GAME_WIDTH / 20+75, GAME_HEIHGT / 10, "ゲームクリア!", GetColor(255, 255, 255), FontHandle::Instance()->Get_weakForce_222_16());
+	DrawStringToHandle(GAME_WIDTH / 20 + 75 + 3, GAME_HEIHGT / 10 + 3, text1, GetColor(0, 0, 0), FontHandle::Instance()->Get_weakForce_222_16());
+	DrawStringToHandle(GAME_WIDTH / 20+75, GAME_HEIHGT / 10, text1, GetColor(255, 255, 255), FontHandle::Instance()->Get_weakForce_222_16());
 
 	//ブレンドモードを通常に戻す
 	SetDrawBlendMode(DX_BLENDMODE_NOBLEND, alpha);
@@ -65,22 +66,43 @@ void GameClear::Draw() {
 	DrawRotaGraph(x, GAME_HEIHGT / 2 + 75, 0.6f, 0, Image::Instance()->GetGraph(eImageType::UI_CursorFrame, 3), TRUE);
 
 	//テキスト表示
-	DrawStringToHandle(GAME_WIDTH / 7 - 5, GAME_HEIHGT / 2 + 50, "もう一度挑戦", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
-	DrawStringToHandle(GAME_WIDTH / 3 + 150 , GAME_HEIHGT / 2 + 50, "メニューに戻る", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+
+	if (x != GAME_X)
+	{
+		DrawStringToHandle(GAME_WIDTH / 7 - 5 + 2, GAME_HEIHGT / 2 + 50, text2, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+		DrawStringToHandle(GAME_WIDTH / 7 - 5, GAME_HEIHGT / 2 + 50, text2, GetColor(128, 128, 128), FontHandle::Instance()->Get_natumemozi_48_8());
+
+		DrawStringToHandle(GAME_WIDTH / 3 + 150 + 3, GAME_HEIHGT / 2 + 50 + 3, text3, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+		DrawStringToHandle(GAME_WIDTH / 3 + 150, GAME_HEIHGT / 2 + 50, text3, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_48_8());
+	}
+	else
+	{
+		DrawStringToHandle(GAME_WIDTH / 7 - 5 + 3, GAME_HEIHGT / 2 + 50+3, text2, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+		DrawStringToHandle(GAME_WIDTH / 7 - 5, GAME_HEIHGT / 2 + 50, text2, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_48_8());
+
+		DrawStringToHandle(GAME_WIDTH / 3 + 150 + 2, GAME_HEIHGT / 2 + 50 + 2, text3, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+		DrawStringToHandle(GAME_WIDTH / 3 + 150, GAME_HEIHGT / 2 + 50, text3, GetColor(128, 128, 128), FontHandle::Instance()->Get_natumemozi_48_8());
+	}
 
 	//キャラ名とセリフ表示
 	switch (charaType)
 	{
 	case 0:
-		DrawStringToHandle(GAME_WIDTH - 500, GAME_HEIHGT - 340, "十六夜 咲夜", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+
+		DrawStringToHandle(GAME_WIDTH - 500, GAME_HEIHGT - 340, text4, GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+
+		DrawStringToHandle(GAME_WIDTH / 13+2, GAME_HEIHGT - 260+2, text5, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_64_8());
+		DrawStringToHandle(GAME_WIDTH / 13, GAME_HEIHGT - 260, text5, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_64_8());
+
 		
-		DrawStringToHandle(GAME_WIDTH / 13, GAME_HEIHGT - 260, "ひたすらデバッグ\nひたすらデバッグ\nひたすらデバッグ", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_64_8());
 		break;
 
 	case 1:
-		DrawStringToHandle(GAME_WIDTH -630, GAME_HEIHGT - 340, "フランドール・スカーレット", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
-	
-		DrawStringToHandle(GAME_WIDTH / 13, GAME_HEIHGT - 260, "ひたすらデバッグ\nひたすらデバッグ\nひたすらデバッグ", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_64_8());
+
+		DrawStringToHandle(GAME_WIDTH -630, GAME_HEIHGT - 340,text6, GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+
+		DrawStringToHandle(GAME_WIDTH / 13+2, GAME_HEIHGT - 260+2, text7, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_64_8());
+		DrawStringToHandle(GAME_WIDTH / 13, GAME_HEIHGT - 260, text7, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_64_8());
 		break;
 
 	default:
@@ -119,19 +141,33 @@ void GameClear::Select()
 
 	//左キーが押された時の処理
 	{
-		if (Input::Instance()->GetPressCount(KEY_INPUT_LEFT) == 1)
+		if (Input::Instance()->GetPressCount(KEY_INPUT_LEFT) % 16 == 1)
 		{
 			SE::Instance()->PlaySE(SE_cursor);
-			nowCursor = Cursor::Cursor_0;
+			if (nowCursor == Cursor::Cursor_0)
+			{
+				nowCursor = Cursor::Cursor_1;
+			}
+			else
+			{
+				nowCursor = Cursor::Cursor_0;
+			}
 		}
 	}
 
 	//右キーが押された時の処理
 	{
-		if (Input::Instance()->GetPressCount(KEY_INPUT_RIGHT) == 1)
+		if (Input::Instance()->GetPressCount(KEY_INPUT_RIGHT) % 16  == 1)
 		{
 			SE::Instance()->PlaySE(SE_cursor);
-			nowCursor = Cursor::Cursor_1;
+			if (nowCursor == Cursor::Cursor_1)
+			{
+				nowCursor = Cursor::Cursor_0;
+			}
+			else
+			{
+				nowCursor = Cursor::Cursor_1;
+			}
 		}
 	}
 

--- a/Source/GameClear.h
+++ b/Source/GameClear.h
@@ -14,6 +14,13 @@ class GameClear final :public BaseScene {
 private:
 	const static int GAME_X;   //「ゲームに戻る」テキスト表示のX座標
 	const static int TITLE_X;     //「タイトルに戻る」テキスト表示のX座標
+	const TCHAR* text1 = "ゲームクリア！";
+	const TCHAR* text2 = "もう一度挑戦";
+	const TCHAR* text3 = "メニューに戻る";
+	const TCHAR* text4 = "十六夜 咲夜";
+	const TCHAR* text5 = "ひたすらデバッグ\nひたすらデバッグ\nひたすらデバッグ";
+	const TCHAR* text6 = "フランドール・スカーレット";
+	const TCHAR* text7 = "ひたすらデバッグ\nひたすらデバッグ\nひたすらデバッグ";
 
 	Cursor nowCursor;           //現在選択中のカーソル
 	int x;                      //カーソル表示用のX座標

--- a/Source/GameOver.cpp
+++ b/Source/GameOver.cpp
@@ -15,8 +15,8 @@ GameOver::GameOver(ISceneChanger* _sceneChanger, Parameter* _parameter) :BaseSce
 //更新
 void GameOver::Update()
 {
-	Select();
 	Move();
+	Select();
 }
 
 //描画
@@ -42,8 +42,8 @@ void GameOver::Draw()
 
 	//ブレンドモードを乗算済みα用のαブレンドにする
 	SetDrawBlendMode(DX_BLENDMODE_PMA_ALPHA, alpha);
-
-	DrawStringToHandle(GAME_WIDTH / 20, GAME_HEIHGT / 10 , "ゲームオーバー", GetColor(255, 255, 255), FontHandle::Instance()->Get_weakForce_222_16());
+	DrawStringToHandle(GAME_WIDTH / 20+3, GAME_HEIHGT / 10+3, text1, GetColor(0, 0, 0), FontHandle::Instance()->Get_weakForce_222_16());
+	DrawStringToHandle(GAME_WIDTH / 20, GAME_HEIHGT / 10 , text1, GetColor(255, 255, 255), FontHandle::Instance()->Get_weakForce_222_16());
 	
 	//ブレンドモードを通常に戻す
 	SetDrawBlendMode(DX_BLENDMODE_NOBLEND, alpha);
@@ -62,22 +62,36 @@ void GameOver::Draw()
 	DrawRotaGraph(x, GAME_HEIHGT / 2 + 75, 0.6f, 0, Image::Instance()->GetGraph(eImageType::UI_CursorFrame, 3), TRUE);
 
 	//テキスト表示
-	DrawStringToHandle(GAME_WIDTH / 7 - 13, GAME_HEIHGT / 2 + 55, "コンティニューする  ", GetColor(255,64,0), FontHandle::Instance()->Get_natumemozi_38_8());
-	DrawStringToHandle(GAME_WIDTH / 2 - 192, GAME_HEIHGT / 2 + 55, "コンティニューしない", GetColor(255,64, 0), FontHandle::Instance()->Get_natumemozi_38_8());
+	if (x != GAME_X)
+	{
+		DrawStringToHandle(GAME_WIDTH / 7 - 13+2, GAME_HEIHGT / 2 + 55+2, text2, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_38_8());
+		DrawStringToHandle(GAME_WIDTH / 2 - 192+2, GAME_HEIHGT / 2 + 55+2, text3, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_38_8());
+		DrawStringToHandle(GAME_WIDTH / 7 - 13, GAME_HEIHGT / 2 + 55, text2, GetColor(128, 128, 128), FontHandle::Instance()->Get_natumemozi_38_8());
+		DrawStringToHandle(GAME_WIDTH / 2 - 192, GAME_HEIHGT / 2 + 55, text3, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_38_8());
+	}
+	else
+	{
+		DrawStringToHandle(GAME_WIDTH / 7 - 13 + 2, GAME_HEIHGT / 2 + 55 + 2, text2, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_38_8());
+		DrawStringToHandle(GAME_WIDTH / 2 - 192 + 2, GAME_HEIHGT / 2 + 55 + 2, text3, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_38_8());
+		DrawStringToHandle(GAME_WIDTH / 7 - 13, GAME_HEIHGT / 2 + 55, text2, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_38_8());
+		DrawStringToHandle(GAME_WIDTH / 2 - 192, GAME_HEIHGT / 2 + 55, text3, GetColor(128, 128, 128), FontHandle::Instance()->Get_natumemozi_38_8());
+	}
 
 	//キャラ名とセリフ表示
 	switch (charaType)
 	{
 	case 0:
-		DrawStringToHandle(GAME_WIDTH - 500, GAME_HEIHGT - 340, "十六夜 咲夜", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+		DrawStringToHandle(GAME_WIDTH - 500, GAME_HEIHGT - 340, text4, GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
 
-		DrawStringToHandle(GAME_WIDTH / 13, GAME_HEIHGT - 260, "ひたすらデバッグ\nひたすらデバッグ\nひたすらデバッグ", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_64_8());
+		DrawStringToHandle(GAME_WIDTH / 13+3, GAME_HEIHGT - 260+3, text5, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_64_8());
+		DrawStringToHandle(GAME_WIDTH / 13, GAME_HEIHGT - 260, text5, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_64_8());
 		break;
 
 	case 1:
-		DrawStringToHandle(GAME_WIDTH - 632, GAME_HEIHGT - 340, "フランドール・スカーレット", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
+		DrawStringToHandle(GAME_WIDTH - 632, GAME_HEIHGT - 340, text6, GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_48_8());
 
-		DrawStringToHandle(GAME_WIDTH / 13, GAME_HEIHGT - 260, "ひたすらデバッグ\nひたすらデバッグ\nひたすらデバッグ", GetColor(255, 64, 0), FontHandle::Instance()->Get_natumemozi_64_8());
+		DrawStringToHandle(GAME_WIDTH / 13+3, GAME_HEIHGT - 260+3, text7, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_64_8());
+		DrawStringToHandle(GAME_WIDTH / 13, GAME_HEIHGT - 260, text7, GetColor(255, 255, 255), FontHandle::Instance()->Get_natumemozi_64_8());
 		break;
 
 	default:
@@ -115,19 +129,33 @@ void GameOver::Select()
 
 	//左キーが押された時の処理
 	{
-		if (Input::Instance()->GetPressCount(KEY_INPUT_LEFT) == 1)
+		if (Input::Instance()->GetPressCount(KEY_INPUT_LEFT) % 16 == 1)
 		{
 			SE::Instance()->PlaySE(SE_cursor);
-			nowCursor = Cursor::Cursor_0;
+			if (nowCursor == Cursor::Cursor_1)
+			{
+				nowCursor = Cursor::Cursor_0;
+			}
+			else
+			{
+				nowCursor = Cursor::Cursor_1;
+			}
 		}
 	}
 
 	//右キーが押された時の処理
 	{
-		if (Input::Instance()->GetPressCount(KEY_INPUT_RIGHT) == 1 )
+		if (Input::Instance()->GetPressCount(KEY_INPUT_RIGHT) % 16 == 1 )
 		{
 			SE::Instance()->PlaySE(SE_cursor);
-			nowCursor = Cursor::Cursor_1;
+			if (nowCursor == Cursor::Cursor_0)
+			{
+				nowCursor = Cursor::Cursor_1;
+			}
+			else
+			{
+				nowCursor = Cursor::Cursor_0;
+			}
 		}
 	}
 

--- a/Source/GameOver.h
+++ b/Source/GameOver.h
@@ -15,7 +15,13 @@ class GameOver :public virtual BaseScene{
 private:
 	const static int GAME_X;    //コンティニューすると表示するテキストのY座標
 	const static int MENU_X;    //コンティニューしないと表示するテキストのY座標
-
+	const TCHAR* text1 = "ゲームオーバー";
+	const TCHAR* text2 = "コンティニューする";
+	const TCHAR* text3 = "コンティニューしない";
+	const TCHAR* text4 = "十六夜 咲夜";
+	const TCHAR* text5 = "ひたすらデバッグ\nひたすらデバッグ\nひたすらデバッグ";
+	const TCHAR* text6 = "フランドール・スカーレット";
+	const TCHAR* text7 = "ひたすらデバッグ\nひたすらデバッグ\nひたすらデバッグ";
 	Cursor nowCursor;           //現在選択中のカーソル
 	int x;                      //カーソル表示用のX座標
 	int alpha;                  //透明度

--- a/Source/GameScene.cpp
+++ b/Source/GameScene.cpp
@@ -40,7 +40,7 @@ void GameScene::Update()
 	eventManager->Update(enemyManager,player);
 	buffManager->Update(itemManager,enemyManager);
 	timeLimit->Update();
-	ui->Update(castleManager, itemManager, buffManager,player);
+	ui->Update(castleManager, itemManager, buffManager,player,timeLimit);
 
 	//ゲームシーンのシーン処理
 	ChangeScene();
@@ -64,9 +64,6 @@ void GameScene::Draw()
 	//森表示
 	DrawTurnGraph(-55, GAME_HEIHGT / 2 - 250, Image::Instance()->GetGraph(eImageType::Gpicture_Forest), TRUE);
 	DrawGraph(GAME_WIDTH - 500, GAME_HEIHGT / 2 - 250, Image::Instance()->GetGraph(eImageType::Gpicture_Forest), TRUE);
-
-	//山表示
-	DrawGraph(0, GAME_HEIHGT - 450 , Image::Instance()->GetGraph(eImageType::Gpicture_Mountain), TRUE);
 
 	eventManager->Draw();
 	timeLimit->Draw();

--- a/Source/Pausemenu.cpp
+++ b/Source/Pausemenu.cpp
@@ -48,13 +48,13 @@ void Pausemenu::PauseAll()
 void Pausemenu::Update()
 {
 
-	if (Input::Instance()->GetPressCount(KEY_INPUT_DOWN) == 1)					//下キーが押されていたら
+	if (Input::Instance()->GetPressCount(KEY_INPUT_DOWN) % 16 == 1)		        //下キーが押されていたら
 	{
 		SE::Instance()->PlaySE(SE_cursor);
 		NowSelect = (NowSelect + 1) % ePausetype_Num;							//選択状態を下げる
 	}
 
-	if (Input::Instance()->GetPressCount(KEY_INPUT_UP) == 1)					//上キーが押されていたら
+	if (Input::Instance()->GetPressCount(KEY_INPUT_UP) % 16 == 1)			    //上キーが押されていたら
 	{
 		SE::Instance()->PlaySE(SE_cursor);
 		NowSelect = (NowSelect + (ePausetype_Num - 1)) % ePausetype_Num;		//選択状態を上げる
@@ -84,21 +84,21 @@ void Pausemenu::Draw()
 	if (NowSelect == ePausetype_Game)
 	{
 		DrawUIGraph(1300, 400, 1300, 350, 1, 1,
-			0, 255, GetColor(0, 0, 0), 2, eDrawType::Center,
+			0, 255, GetColor(255, 255, 255), 3, eDrawType::Center,
 			FontHandle::Instance()->Get_natumemozi_100_3(), 205, "ゲームに戻る");
 
 		DrawUIGraph(1300, 750, 1300, 350, 1, 1,
-			0, 255, GetColor(0, 0, 0), 0, eDrawType::Center,
+			0, 255, GetColor(255, 255, 255), 0, eDrawType::Center,
 			FontHandle::Instance()->Get_natumemozi_100_3(), 180, "メニューに戻る");
 	}
 	else
 	{
 		DrawUIGraph(1300, 400, 1300, 350, 1, 1,
-			0, 255, GetColor(0, 0, 0), 0, eDrawType::Center,
+			0, 255, GetColor(255, 255, 255), 0, eDrawType::Center,
 			FontHandle::Instance()->Get_natumemozi_100_3(), 205, "ゲームに戻る");
 
 		DrawUIGraph(1300, 750, 1300, 350, 1, 1,
-			0, 255, GetColor(0, 0, 0), 2, eDrawType::Center,
+			0, 255, GetColor(255, 255, 255), 3, eDrawType::Center,
 			FontHandle::Instance()->Get_natumemozi_100_3(), 180, "メニューに戻る");
 	}
 

--- a/Source/Title.cpp
+++ b/Source/Title.cpp
@@ -22,6 +22,11 @@ void Title::Update()
 		BGM::Instance()->StopBGM(BGM_title);
 		sceneChanger->SceneChange(eScene_MENU, parameter, false, false);
 	}
+	if (Input::Instance()->GetPressCount(KEY_INPUT_ESCAPE) == 1) 
+	{
+		//ƒQ[ƒ€‚ğI—¹‚·‚é
+		exit(EXIT_SUCCESS);
+	}
 }
 
 void Title::Draw()


### PR DESCRIPTION
## 概要

ゲームオーバー、クリアのシーンのテキストに影を追加、キー長押しでカーソルが動き続けるように
ゲームシーンのUIに引数の追加、背景の山の削除
サブ拠点のHPを25に下方修正
タイトルでESCキーを押したらゲームを閉じるように
ポーズメニューのカーソルを青に変更、キー長押しでカーソルが動き続けるように
## 技術的変更点概要

## 今回保留した項目とTODOリスト

## その他
