### PR TITLE
[update]文字の色を選択されてないところは灰色に、Xキーでもゲームに戻れるように

### DIFF
--- a/Source/Pausemenu.cpp
+++ b/Source/Pausemenu.cpp
@@ -59,6 +59,13 @@ void Pausemenu::Update()
 		SE::Instance()->PlaySE(SE_cursor);
 		NowSelect = (NowSelect + (ePausetype_Num - 1)) % ePausetype_Num;		//選択状態を上げる
 	}
+
+	if (Input::Instance()->GetPressCount(KEY_INPUT_X) == 1)				        //Xキーが押された場所の処理
+	{
+		BGM::Instance()->VolumeBGM(BGM::Instance()->Get_Volume());
+		sceneChanger->SceneChange(eScene_GAME, parameter, false, true);
+	}
+
 	if (Input::Instance()->GetPressCount(KEY_INPUT_Z) == 1)				        //Zキーが押された場所の処理
 	{
 		BGM::Instance()->VolumeBGM(BGM::Instance()->Get_Volume());
@@ -88,13 +95,13 @@ void Pausemenu::Draw()
 			FontHandle::Instance()->Get_natumemozi_100_3(), 205, "ゲームに戻る");
 
 		DrawUIGraph(1300, 750, 1300, 350, 1, 1,
-			0, 255, GetColor(255, 255, 255), 0, eDrawType::Center,
+			0, 255, GetColor(128, 128, 128), 0, eDrawType::Center,
 			FontHandle::Instance()->Get_natumemozi_100_3(), 180, "メニューに戻る");
 	}
 	else
 	{
 		DrawUIGraph(1300, 400, 1300, 350, 1, 1,
-			0, 255, GetColor(255, 255, 255), 0, eDrawType::Center,
+			0, 255, GetColor(128, 128, 128), 0, eDrawType::Center,
 			FontHandle::Instance()->Get_natumemozi_100_3(), 205, "ゲームに戻る");
 
 		DrawUIGraph(1300, 750, 1300, 350, 1, 1,


### PR DESCRIPTION
## 概要

選択されてないところはテキストを灰色に、Xキーでもゲームシーンに戻れるようにしました

## 技術的変更点概要

## 今回保留した項目とTODOリスト

## その他

