### PR TITLE
[fix]最強チャージショットの修正。スキル時下からカットインが出てくるように

### DIFF
--- a/Source/BasePlayer.cpp
+++ b/Source/BasePlayer.cpp
@@ -22,7 +22,7 @@ BasePlayer::BasePlayer(int _pType)
 	if (playerType == SAKUYA)
 	{
 		speed = 8;					//移動速度
-		power = 40;					//攻撃力
+		power = 30;					//攻撃力
 		abilityCount = 3;		    //スキル回数
 		graphNo = 2;
 		animNo = 2;
@@ -33,7 +33,7 @@ BasePlayer::BasePlayer(int _pType)
 	if (playerType == FRAN)
 	{
 		speed = 3;					//移動速度
-		power = 80;			        //攻撃力
+		power = 50;			        //攻撃力
 		abilityCount = 2;		    //スキル回数
 		graphNo = 0;
 		animNo = 0;
@@ -70,6 +70,10 @@ BasePlayer::BasePlayer(int _pType)
 	drawZoom = 1.0;             //描画の拡大率
 
 	shotPower = 0;              //チャージゲージ
+	fadeCount = 0;              //カットインカウント
+
+	catX = 400;
+	catY = 850;
 }
 
 void BasePlayer::Draw()
@@ -109,8 +113,21 @@ void BasePlayer::Draw_Ability()
 	{
 		//魔法陣ブワァァァ
 		DrawRotaGraph(pos.x + 24, pos.y + 24, drawZoom, PI * drawAngle, Image::Instance()->GetGraph(eImageType::Gpicture_Magic), TRUE);
-		int test = LoadGraph("./res/Image/Timer.png");
-		Image::Instance()->TransparentGraph(800, 300, test, 80, true);
+
+		if (playerType == SAKUYA) {
+			//カットイン(白目)
+			//クソ地味だからカットインの左側にセリフでも入れようかな。後効果音
+			fadeCount = Image::Instance()->FadeInGraph(catX, catY, Image::Instance()->GetGraph(eImageType::Spicture_SelectPlayer, 0), fadeCount, 250);
+		}
+		else
+		{
+			//カットイン(白目)
+			fadeCount = Image::Instance()->FadeInGraph(catX, catY, Image::Instance()->GetGraph(eImageType::Spicture_SelectPlayer, 1), fadeCount, 250);
+		}
+
+		//下からカットイン
+		catY--;
+		
 	}
 
 }
@@ -142,13 +159,13 @@ void BasePlayer::Update(EnemyManager* _eManager, BuffManager* _bManager)
 
 	if (playerType == SAKUYA)
 	{
-		power = 40 * _bManager->GetPowerBuff();   //バフによる攻撃力増加
+		power = power * _bManager->GetPowerBuff();   //バフによる攻撃力増加
 		speed = 5 * _bManager->GetSpeedBuff();   //バフによるスピード増加
 
 	}
 	if (playerType == FRAN)
 	{
-		power = 80 * _bManager->GetPowerBuff();   //バフによる攻撃力増加
+		power = power * _bManager->GetPowerBuff();   //バフによる攻撃力増加
 		speed = 3 * _bManager->GetSpeedBuff();   //バフによるスピード増加
 
 	}

--- a/Source/BasePlayer.h
+++ b/Source/BasePlayer.h
@@ -84,6 +84,9 @@ protected:
 	const int STOPTIME = 5;         //時止めスキルの時間
 	int abilityTimer;               //スキル発動時間
 	int countDown;                  //スキルタイマーのカウントダウンに使用
+	int fadeCount;                  //スキルカットインのカウント
+	int catX;                       //カットイン用
+	int catY;
 
 	//フランスキル用
 	const int FRANTIME = 3;

--- a/Source/Bullet.cpp
+++ b/Source/Bullet.cpp
@@ -72,14 +72,11 @@ void Bullet::Update(EnemyManager* _eManager,BasePlayer* _basePlayer)
 		//チャージゲージがMAXなら攻撃力UP
 		if (shotPower == 100)
 		{
-			if (_basePlayer->Get_AbilityType() == FRAN) {
-				power = power + 100;
-				
-			}
-			else
-			{
-				power = power + 100;
-			}
+			power = 200;
+		}
+		else
+		{
+			power = _basePlayer->Get_power();
 		}
 		if (bullet_Move == eDirection::Left)
 		{

--- a/Source/Ui.cpp
+++ b/Source/Ui.cpp
@@ -133,9 +133,6 @@ void UI::ChargeGage()
 {
 	DrawBox(10, 950, 380, 1050, GetColor(200, 200, 200), TRUE);		//後ろに敷く
 	DrawFormatStringToHandle(15, 950, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_38_8(), "チャージゲージ");
-	DrawFormatStringToHandle(15, 750, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_38_8(), "%d",chageGauge);
-	DrawFormatStringToHandle(15, 550, GetColor(0, 0, 0), FontHandle::Instance()->Get_natumemozi_38_8(), "%d", playerPower);
-
 	//チャージゲージの枠
 	DrawBox(CHARGEGAUGE_X-1, CHARGEGAUGE_Y-1,CHARGEGAUGE_X2+1, CHARGEGAUGE_Y2+1, GetColor(0, 0, 0), FALSE);	
 


### PR DESCRIPTION
## 概要

①チャージショットの修正 Bullet.cpp

②スキル時下からカットインが出る用に。 BasePlaer.cpp

## 技術的変更点概要

ーーー

## 今回保留した項目とTODOリスト

スキルカットインが相変わらず地味なので、SEと+aを追加したい （カットインの左側にセリフとかスペカ名とか

## その他

* レビュワーに対する注意点 (ここはこういう風に思ったけどこういう風に実装した、ここはこうしようと思ったんだけどこういう悩みがありやめた、など注意点があれば)
